### PR TITLE
before_filter on contact_messages and notes field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,9 @@ gem 'jquery-rails', '>= 1.0.12'
 
 gem 'sqlite3-ruby', :require => 'sqlite3'
 gem 'mysql'
-gem 'pg'
+group :production do
+	gem 'pg'
+end
 
 # Use unicorn as the web server
 # gem 'unicorn'

--- a/app/controllers/contact_messages_controller.rb
+++ b/app/controllers/contact_messages_controller.rb
@@ -1,4 +1,5 @@
 class ContactMessagesController < ApplicationController
+	before_filter :check_admin, :only => [:destroy, :edit, :list]
 
 	def new
 		@admins = Person.find_all_by_is_admin(true)
@@ -11,7 +12,7 @@ class ContactMessagesController < ApplicationController
 
 		if @new.save
 			flash[:notice] = "Thank you for your feedback. An administrator will read your message shortly and we will take appropriate action."
-			redirect_to :contact_messages
+			redirect_to new_contact_message_url
 		else
 			flash[:error] = @new.errors.full_messages.first
 			# TODO: Determine better way to maintain the input in the fields than copy & pasting the code
@@ -36,5 +37,21 @@ class ContactMessagesController < ApplicationController
 		@message.visible = false
 		@message.save()
 		redirect_to list_contact_messages_url()
+	end
+
+	def edit
+		@contact_message = ContactMessage.find(params[:id])
+	end
+
+	def update
+		@contact_message = ContactMessage.find(params[:id])
+		
+		if @contact_message.update_attributes(params[:contact_message])
+			flash[:notice] = "Note updated"
+			redirect_to list_contact_messages_url
+		else
+			flash[:error] = @contact_message.errors.full_messages.first
+			render :edit
+		end
 	end
 end

--- a/app/views/contact_messages/edit.html.haml
+++ b/app/views/contact_messages/edit.html.haml
@@ -1,0 +1,16 @@
+- unless flash[:notice].nil?
+  %div.notice=flash[:notice]
+%div
+  %table
+    %thead
+      %th{:colspan=>2} Edit Note
+    %tbody
+      -form_for(@contact_message) do |j|
+        %tr
+          %td= j.label :note, "Notes regarding this: "
+          %td= j.text_area :note
+        %tr
+          %td
+            &nbsp;
+          %td=j.submit "Submit Comment"
+  

--- a/app/views/contact_messages/list.html.haml
+++ b/app/views/contact_messages/list.html.haml
@@ -3,7 +3,9 @@
     %th From
     %th Regarding
     %th Body
+    %th Note
     %th Occurred
+    %th Edit
     %th.admin Delete
   %tbody
     - @messages.each do |m|
@@ -11,5 +13,7 @@
         %td=m.from
         %td=m.regarding
         %td=m.body
+        %td=m.note
         %td=m.occurred.strftime("%A, %B %e, %Y @ %I:%M %p")
-        %td=link_to("Delete", delete_contact_message_url(m), :class=>"admin", :method=>:delete)
+        %td=link_to("Edit", edit_contact_message_url(m))
+        %td=link_to("Delete", contact_message_url(m), :class=>"admin", :method=>:delete)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,10 +29,11 @@ Hvz::Application.routes.draw do
 	match 'games/:id/rules' => "games#rules", :as => "game_rules"
 	match 'games/:id/graphdata' => "games#graphdata", :as => "game_graph_data"
 	match 'games/:id/tree' => "games#tree", :as => "game_tree"
-	match "/contact/" => "contact_messages#new", :as=>"contact_messages", :via => "get"
-	match "/contact/" => "contact_messages#create", :as => "new_contact_message",:via => "post"
-	match "/contact/list(/:all)" => "contact_messages#list", :as => "list_contact_messages", :via=>"get"
-	match "/contact/:id" => "contact_messages#destroy", :as => "delete_contact_message", :via=>"delete"
+	resources :contact, :as => :contact_messages, :controller => :contact_messages do
+		collection do
+			get :list
+		end
+	end
 
   match "squads/:id" => "squad#show", :as=> "squad"
   match "squads" => "squad#index", :as=> "squads"

--- a/db/migrate/20121002143805_add_note_to_contact_messages.rb
+++ b/db/migrate/20121002143805_add_note_to_contact_messages.rb
@@ -1,0 +1,9 @@
+class AddNoteToContactMessages < ActiveRecord::Migration
+  def self.up
+    add_column :contact_messages, :note, :text
+  end
+
+  def self.down
+    remove_column :contact_messages, :note
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120928194457) do
+ActiveRecord::Schema.define(:version => 20121002143805) do
 
   create_table "attendances", :force => true do |t|
     t.integer   "registration_id"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(:version => 20120928194457) do
     t.timestamp "updated_at"
     t.integer   "game_id"
     t.boolean   "visible",    :default => true
+    t.text      "note"
   end
 
   create_table "delayed_jobs", :force => true do |t|


### PR DESCRIPTION
Runs check_admin filter on contact_messages edit/destroy/list.  Adds an edit page which just contains a text area for notes.  Allows admins to make a comment on the message to note what they did.
Contains a migration that needs run for it to work.
