### PR TITLE
Added text to the OZ checkbox description

### DIFF
--- a/app/views/registrations/new.html.haml
+++ b/app/views/registrations/new.html.haml
@@ -40,7 +40,7 @@
         = form_for(@registration) do |f|
           %tr
             %td
-              %b=f.label :wants_oz, "Place me in the Original Zombie Pool:"
+              %b=f.label :wants_oz, "Place me in the Original Zombie Pool! \n Note- An Original Zombie should dedicate at least 6 hours to hunting in the first 3 days:"
             %td
               =f.check_box :wants_oz
           %tr


### PR DESCRIPTION
text adds request for players wanting OZ to have at least 6 hours to hunt in early game - intended to be replaced in future with a popup